### PR TITLE
Add condition to be able to use .ZIP files instead of only .TXT

### DIFF
--- a/b3fileparser/b3parser.py
+++ b/b3fileparser/b3parser.py
@@ -1,35 +1,45 @@
 import pandas as pd
 from b3fileparser import b3_meta_data
+from zipfile import ZipFile
+from io import BytesIO
 
 
-def read_b3_file(file_name):    
-    if not file_name.endswith('TXT'):
-        print('Invalid format! Provide a .TXT file ')
+def read_b3_file(file_name):
+    if file_name.endswith('.ZIP'):
+        file_zip = ZipFile(file_name, mode='r')
+        file_txt = file_zip.read(file_name.replace('.ZIP', '.TXT'))
+        file = BytesIO(file_txt)
+    if file_name.endswith('.TXT'):
+        file = file_name
+    if not (file_name.endswith('TXT') or file_name.endswith('ZIP')):
+        print('Invalid format! Provide a .TXT or .ZIP file containing a .TXT')
         return
     columns = []
     size_fields = []
 
-    for col, info in b3_meta_data.META_DATA.items():   
+    for col, info in b3_meta_data.META_DATA.items():
         columns.append(info['name'])
         size_fields.append(info['size'])
 
-    b3_data = pd.read_fwf(file_name, widths=size_fields, header=None, names=columns)[1:-1]
+    b3_data = pd.read_fwf(file, widths=size_fields,
+                          header=None, names=columns)[1:-1]
 
     for col in columns:
         if col.startswith('PRECO') or col.startswith('VOLUME'):
             b3_data[col] = b3_data[col] / 100
         if col == "DATA_DE_VENCIMENTO":
-            b3_data[col] = b3_data[col].astype(int).astype(str)                
-            b3_data[col] = pd.to_datetime(b3_data[col], errors='coerce')      
+            b3_data[col] = b3_data[col].astype(int).astype(str)
+            b3_data[col] = pd.to_datetime(b3_data[col], errors='coerce')
         if col.startswith('DATA'):
-            b3_data[col] = pd.to_datetime(b3_data[col])    
-        if col in ["CODIGO_BDI", "PRAZO_EM_DIAS_DO_MERCADO_A_TERMO","NUMERO_DE_DISTRIBUICAO", "FATOR_DE_COTACAO", 'INDICADOR_DE_CORRECAO_DE_PRECOS']:
+            b3_data[col] = pd.to_datetime(b3_data[col])
+        if col in ["CODIGO_BDI", "PRAZO_EM_DIAS_DO_MERCADO_A_TERMO", "NUMERO_DE_DISTRIBUICAO", "FATOR_DE_COTACAO", 'INDICADOR_DE_CORRECAO_DE_PRECOS']:
             b3_data[col] = b3_data[col].fillna(-1).astype(int)
         if col == "TIPO_DE_MERCADO":
-            b3_data[col] = b3_data[col].apply(lambda x: b3_meta_data.MARKETS[x])        
+            b3_data[col] = b3_data[col].apply(
+                lambda x: b3_meta_data.MARKETS[x])
         if col == "INDICADOR_DE_CORRECAO_DE_PRECOS":
-            b3_data[col] = b3_data[col].apply(lambda x: b3_meta_data.INDOPC[x]) 
+            b3_data[col] = b3_data[col].apply(lambda x: b3_meta_data.INDOPC[x])
         if col == "CODIGO_BDI":
             b3_data[col] = b3_data[col].apply(lambda x: b3_meta_data.CODBDI[x])
-    
+
     return b3_data


### PR DESCRIPTION
Added two if statements to verify if it's a .ZIP file, if so, it will open the .TXT inside the .ZIP. if not, it will follow with the .TXT file as usual. This way you don't need to manually extract the .TXT from .ZIP beforehand.