### PR TITLE
fix encoding error 

### DIFF
--- a/b3fileparser/b3parser.py
+++ b/b3fileparser/b3parser.py
@@ -27,7 +27,8 @@ def read_b3_file(file_name):
         file,
         widths=size_fields,
         header=None,
-        names=columns
+        names=columns,
+        encoding='latin1'
     )[1:-1]
 
     for col in columns:


### PR DESCRIPTION
UnicodeDecodeError: 'utf-8' codec can't decode byte 0xc7 in position 7188: invalid continuation byte"
}
add 'latin1' encoding... erro começa em arquivos a partir de 2012